### PR TITLE
Proposed feature: `overrideElementAttribute`

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This feature can be used to build [interactive experiences](https://warcembed-de
 | `updateTs` | Number | If provided, will replace the current `ts` parameter of `<replay-web-page>`. |
 | `getCollInfo` | Boolean | If provided, will send a post message back with `<replay-web-page>`'s `collInfo` object, containing meta information about the currently-loaded archive. |
 | `getInited` | Boolean | If provided, will send a post message back with the current value of `<replay-web-page>`s `inited` property, indicating whether or not the service worker is ready. |
-| `overrideElementAttribute` | !!Add type description here!! | If provided, will look for the element with the specified CSS selector inside `<replay-web-page>` and if found, apply the requested HTML attribute to it. If the element is not found, will send a post message back reporting `"status": "timed out"`, along with a copy of the original message's `data`. |
+| `overrideElementAttribute` | [`HTMLAttributeOverride`](https://github.com/harvard-lil/wacz-exhibitor/blob/main/html/embed/index.js) | If provided, will look for the element with the specified CSS selector inside `<replay-web-page>` and if found, apply the requested HTML attribute to it. If the element is not found, will send a post message back reporting `"status": "timed out"`, along with a copy of the original message's `data`. |
 
 ### Messages hoisted from `<replay-web-page>`
 `wacz-exhibitor` will forward to the embedding website every post message sent by `<replay-web-page>`'s service worker. 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ This feature can be used to build [interactive experiences](https://warcembed-de
 | `updateUrl` | String | If provided, will replace the current `url` parameter of `<replay-web-page>`. |
 | `updateTs` | Number | If provided, will replace the current `ts` parameter of `<replay-web-page>`. |
 | `getCollInfo` | Boolean | If provided, will send a post message back with `<replay-web-page>`'s `collInfo` object, containing meta information about the currently-loaded archive. |
-| `getInited` | Boolean | If provided, will send a post message back with the current value of `<replay-web-page>`s `inited` property, indicating whether or not the service worker is ready. | 
+| `getInited` | Boolean | If provided, will send a post message back with the current value of `<replay-web-page>`s `inited` property, indicating whether or not the service worker is ready. |
+| `overrideElementAttribute` | !!Add type description here!! | If provided, will look for the element with the specified CSS selector inside `<replay-web-page>` and if found, apply the requested HTML attribute to it. If the element is not found, will send a post message back reporting `"status": "timed out"`, along with a copy of the original message's `data`. |
 
 ### Messages hoisted from `<replay-web-page>`
 `wacz-exhibitor` will forward to the embedding website every post message sent by `<replay-web-page>`'s service worker. 

--- a/html/embed/index.js
+++ b/html/embed/index.js
@@ -208,6 +208,8 @@ async function waitForElement(selectorFunction) {
       if (!err.message.includes('null')) {
         throw err;
       }
+    }
+    if (!elem) {
       tries -= 1;
     }
   }

--- a/html/embed/index.js
+++ b/html/embed/index.js
@@ -185,8 +185,6 @@ class TimeoutError extends Error {
  * Waits for a given element to be in the DOM and returns it.
  * Wait is based on `requestAnimationFrame`: timeout is approximately 60 seconds (60 x 60 frames per seconds).
  *
- * Takes a function querying the DOM for a single element as an argument
- *
  * @param {function} selectorFunction - Function to be run to find the element.
  * @returns {Promise<HTMLElement>} Reference to the element that was found.
  */

--- a/html/embed/index.js
+++ b/html/embed/index.js
@@ -173,7 +173,10 @@ function handleTsParam(ts) {
   return ts;
 }
 
-class TimeoutError extends Error {
+/**
+ * To be thrown whenever `waitForElement` fails to find an element after exhausting all allowed retries.
+ */
+class WaitForElementTimeoutError extends Error {
   constructor(message) {
     super(message);
     this.name = "TimeoutError";
@@ -216,7 +219,7 @@ async function waitForElement(selectorFunction) {
     return elem;
   }
 
-  throw new TimeoutError(`Did not find element in ${maxPauseSeconds}s`);
+  throw new WaitForElementTimeoutError(`Did not find element in ${maxPauseSeconds}s`);
 }
 
 /**

--- a/html/embed/index.js
+++ b/html/embed/index.js
@@ -168,7 +168,7 @@ function handleTsParam(ts) {
  * Takes a function querying the DOM for a single element as an argument
  */
 async function waitForElement(selectorFunction) {
-  const maxPauseSeconds = 60
+  const maxPauseSeconds = 60;
   let tries = maxPauseSeconds * 60;  // we expect a repaint rate of ~60 times a second, per https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame
   let elem = null;
 

--- a/html/embed/index.js
+++ b/html/embed/index.js
@@ -200,7 +200,7 @@ async function waitForElement(selectorFunction) {
  * Async helper function for handling `overrideElementAttribute` messages.
  * Posts `overrideElementAttribute` back to the parent frame on failure.
  */
-async function overrideElementAttribute(origin, player, parent, selector, attributeName, attributeContents){
+async function overrideElementAttribute(origin, player, parent, selector, attributeName, attributeContents) {
   try {
     const targetElem = await waitForElement(() => {
       return player.shadowRoot

--- a/html/embed/index.js
+++ b/html/embed/index.js
@@ -227,7 +227,7 @@ async function waitForElement(selectorFunction) {
  *
  * @param {string} origin - The origin of the posted message (see: https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/origin).
  * @param {HTMLElement} player - The <replay-web-page> element.
- * @param {HTMLElement} parent - https://developer.mozilla.org/en-US/docs/Web/API/Window/parent
+ * @param {Window} parent - https://developer.mozilla.org/en-US/docs/Web/API/Window/parent
  * @param {HTMLAttributeOverride} overrideElementAttribute - Specifies which HTML element to change, and how.
  * @returns {Promise<void>}
  */

--- a/html/embed/index.js
+++ b/html/embed/index.js
@@ -173,6 +173,14 @@ function handleTsParam(ts) {
   return ts;
 }
 
+class TimeoutError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "TimeoutError";
+    this.timeOutError = true;
+  }
+}
+
 /**
  * Waits for a given element to be in the DOM and returns it.
  * Wait is based on `requestAnimationFrame`: timeout is approximately 60 seconds (60 x 60 frames per seconds).
@@ -208,7 +216,7 @@ async function waitForElement(selectorFunction) {
     return elem;
   }
 
-  throw new Error("Timed out");
+  throw new TimeoutError(`Did not find element in ${maxPauseSeconds}s`);
 }
 
 /**
@@ -241,7 +249,7 @@ async function overrideElementAttribute(origin, player, parent, overrideElementA
     targetElem.setAttribute(attributeName, attributeContents);
   }
   catch(err) {
-    if (!err.message.includes('Timed out')) {
+    if (!('timeOutError' in err)) {
       throw err;
     }
     parent.window.postMessage(


### PR DESCRIPTION
This PR proposes a feature that will allow hosts to improve specific playback experiences by altering the attributes of a targeted HTML element in the playback.

Examples:
- adding missing `alt` attributes to images for improved accessibility
- hiding disruptive modals (like Facebook login prompts)
- calling attention to / "highlighting" a section of a playback

It adds a new event to the existing `postMessage` listener, `overrideElementAttribute`. Provided a CSS selector, an attribute name, and attribute contents...
```
      frame.contentWindow.postMessage(
        {"overrideElementAttribute": {
          "selector": "img",
          "attributeName": "style",
          "attributeContents": "display: block; margin: auto; width: auto; height: auto;"
        }},
        origin
      );
```
... it looks for the element with the specified element inside `<replay-web-page>` and if found, applies the requested HTML attribute to it. If the element is not found, it sends a post message back reporting `"status": "timed out"`, along with a copy of the original message's `data`.

### Concerns

This may be controversial: a person might think that no aspect of a playback should be altered, and that any such move compromises the integrity of the playback.

But I think that is not the case. Instead, I think that playback software should expose a clear API for making certain kinds of alterations, and then should make it easy for a user to see an explicit list of what has been changed, and toggle changes off and on.

This PR is a step in that direction.

We could definitely decide that is not the direction we want to go.

### In action

You can see this functionality now at https://perma.cc/A55W-FADV?type=image: observe that the screenshot is centered and fills the screen and has an alt text.
