### PR TITLE
Added a development sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,18 @@ The following example describes the process of deploying `wacz-exhibitor` on [fl
 ```bash
 docker build . -t wacz-exhibitor-local
 docker run --rm -p 8080:8080 wacz-exhibitor-local
-# wacz-exhibitor is now accessible on http://localhost:8080
+# wacz-exhibitor is now accessible at http://localhost:8080
+```
+
+### Development Sandbox
+A minimal sandbox is available to test embedding wacz-exhibitor `<iframe>`s in webpages.
+
+You may edit `sandbox/index.html` to make it point to a specific web archive file  and run the following command to start the sandbox:
+
+```bash
+# Assuming: wacz-exhibitor is running on port 8080 ...
+bash start-sandbox.sh
+# The sandbox is now accessible at http://localhost:8000
 ```
 
 [☝️ Back to summary](#summary)

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>wacz-exhibitor sandbox</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow"/>
+
+    <style type="text/css">
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      font-family: monospace;
+      font-size: 18px;
+    }
+
+    body {
+      width: 100%;
+      text-align: center;
+    }
+
+    iframe {
+      display: block;
+      width: 90%;
+      max-width: 90%;
+      min-height: 85vh;
+      margin: auto;
+      border: 0.25rem solid black;
+      border-radius: 0.5rem;
+    }
+    </style>
+  </head>
+
+  <body id="item">
+    
+    <h1>wacz-exhibitor sandbox</h1>
+
+    <p>Test: embedding a wacz-exhibitor <code>&lt;iframe&gt;</code></p>
+
+    <iframe 
+      src="http://localhost:8080/?source=MY-FILE.wacz&url=page:0" 
+      sandbox="allow-scripts allow-modals allow-forms allow-same-origin allow-downloads"
+    ></iframe>
+
+  </body>
+
+</html>

--- a/start-sandbox.sh
+++ b/start-sandbox.sh
@@ -1,0 +1,3 @@
+# Serves the files present in the "sandbox" folder, for testing purposes.
+cd sandbox;
+python3 -m http.server;


### PR DESCRIPTION
As discussed w/ @rebeccacremona: added a development sandbox to help with testing.

This sandbox consists of a single HTML file -- served via `python3 -m http.server` -- allowing developers to test embedded wacz-exhibitor `<iframe>`s locally.