### PR TITLE
Add `noSandbox` param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Must be embedded in a cross-origin `<iframe>`, preferably on the same parent dom
 | `ts`| No | Timestamp of the page to retrieve. Can be either a YYYYMMDDHHMMSS-formatted string or a millisecond timestamp or a. |
 | `embed` | No | `<replay-web-page>`'s [embed mode](https://replayweb.page/docs/embedding). Can be set to `replayonly` to hide its UI. |
 | `deepLink` | No | `<replay-web-page>`'s [`deepLink` mode](https://replayweb.page/docs/embedding). |
+| `noSandbox` | No | If set, will remove the [`sandbox`](https://replayweb.page/docs/embedding) from the `<replay-web-page>` iframe. May be necessary for [certain playbacks](https://github.com/harvard-lil/wacz-exhibitor/issues/23); e.g., cross-browser compatible playbacks of PDFs. |
 
 #### Examples
 ```html

--- a/html/embed/index.js
+++ b/html/embed/index.js
@@ -28,7 +28,6 @@ player.setAttribute("source", `/${params.get("source")}`);
 player.setAttribute("replayBase", "/replay-web-page/");
 player.setAttribute("embed", "default");
 player.setAttribute("requireSubDomainIframe", "");
-player.setAttribute("sandbox", "");
 
 // Param: `url` (see: https://replayweb.page/docs/embedding)
 if (params.get("url")) {
@@ -49,6 +48,13 @@ if (["default", "full", "replayonly", "replay-with-info"].includes(params.get("e
 if (params.get("deepLink")) {
   player.setAttribute("deepLink", "");
 }
+
+// Param: `noSandbox` (see: https://replayweb.page/docs/embedding)
+// Default to sandboxing playbacks, but allow the host to override.
+if (!params.get("noSandbox")){
+  player.setAttribute("sandbox", "");
+}
+
 
 document.querySelector("body").appendChild(player);
 


### PR DESCRIPTION
This PR implements the `noSandbox` param proposed in https://github.com/harvard-lil/wacz-exhibitor/issues/23.

### In action

You can see this functionality now by inspecting the DOM at https://perma.cc/F525-REKS.