### PR TITLE
Updated path for overrideElementAttribute()

### DIFF
--- a/html/embed/index.js
+++ b/html/embed/index.js
@@ -247,7 +247,7 @@ async function overrideElementAttribute(origin, player, parent, overrideElementA
         .contentDocument
         .querySelector('replay-app-main')
         .shadowRoot
-        .querySelector('wr-coll')
+        .querySelector('wr-item')
         .shadowRoot
         .querySelector('wr-coll-replay')
         .shadowRoot


### PR DESCRIPTION
wr-coll > wr-item in replayweb.page 2.0.0