### PR TITLE
Modify Dockerfile And Add Example Docker Compose Stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,2 @@
 FROM nginx:latest
 COPY ./html/ /usr/share/nginx/html/
-COPY ./nginx.conf /etc/nginx/conf.d/nginx.conf

--- a/README.md
+++ b/README.md
@@ -102,13 +102,20 @@ Will first look for the path + file given in the local [`/archives/` folder](/ht
 ## Deployment
 This project consists of a single `Dockerfile` derived from [the official NGINX Docker image](https://hub.docker.com/_/nginx), which can be deployed on any docker-compatible machine. 
 
-### Example
+### Fly.io Example
 The following example describes the process of deploying `wacz-exhibitor` on [fly.io](https://fly.io), a platform-as-a-service provider. 
 1. `nginx.conf` needs to be edited. See comments starting with `EDIT:` in the document for instructions.
 2. Install the [`flyctl`](https://fly.io/docs/hands-on/install-flyctl/) client and [sign-in](https://fly.io/docs/hands-on/sign-in/), if not already done.
 3. Initialize and deploy the project by running the `flyctl launch` command _(use `flyctl deploy` for subsequent deploys)_. 
 4. `wacz-exhibitor` is now live and visible on the [`fly.io` dashboard](https://fly.io/dashboard). 
 5. We highly recommend setting up a **custom domain and SSL certificate**. This can be done directly from the `fly.io` dashboard. Ideally, the target domain should be a subdomain of the website on which `wacz-exhibitor` iframes are going to be embedded: for example, `www.domain.ext` embedding an `<iframe>` from `wacz.domain.ext`.
+
+### Docker Compose Example
+
+The following example describes the process of deploying `wacz-exhibitor` on your own infrastructure with Docker Compose.
+1. `nginx.conf` needs to be edited. See comments starting with `EDIT:` in the document for instructions.
+2. Run `docker compose up -d`. The `-d` is important! Without it, the service will stop when your terminal session disconnects or you hit CTRL+C.
+3. `wacz-exhibitor` is now accessible on `localhost:8080`
 
 [☝️ Back to summary](#summary)
 

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -7,4 +7,4 @@ services:
       # Place your archives in ./archives
       - ./archives:/usr/share/nginx/html/archives
     ports:
-      - 80:80
+      - 8080:80

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -7,4 +7,4 @@ services:
       # Place your archives in ./archives
       - ./archives:/usr/share/nginx/html/archives
     ports:
-      - 8080:80
+      - 8080:8080

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -1,0 +1,10 @@
+services:
+  wacz-exhibitor:
+    build: .
+    volumes:
+      # Edit the example nginx.conf as needed
+      - ./nginx.conf:/etc/nginx/conf.d/nginx.conf
+      # Place your archives in ./archives
+      - ./archives:/usr/share/nginx/html/archives
+    ports:
+      - 80:80


### PR DESCRIPTION
I wanted to run this on my own server and realized the default Docker setup wasn't ideal for use with Docker Compose so I made some changes that shouldn't impact the existing workflow other than that the Dockerfile no longer bundles the nginx.conf at build time (see the commit message for an elaboration on why I chose to do this).